### PR TITLE
Add Clang Build&Test action

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,13 +7,8 @@ env:
   BUILD_TYPE: Debug
 
 jobs:
-  build:
-    # The CMake configure and build commands are platform agnostic and should work equally
-    # well on Windows or Mac.  You can convert this to a matrix build if you need
-    # cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  build-gcc:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Build & Test
@@ -21,9 +16,24 @@ jobs:
       with:
         submodule-update: true
         source-dir: ${{github.workspace}}/cpp
-        build-dir: ${{ runner.workspace }}/build
+        build-dir: ${{github.workspace}}/build
         cc: gcc
         cxx: g++
+        build-type: Release
+        run-test: true
+        install-build: false
+  build-clang:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build & Test
+      uses: ashutoshvarma/action-cmake-build@master
+      with:
+        submodule-update: true
+        source-dir: ${{github.workspace}}/cpp
+        build-dir: ${{github.workspace}}/build
+        cc: clang
+        cxx: clang++
         build-type: Release
         run-test: true
         install-build: false


### PR DESCRIPTION
Duplicate the CMake build and test workflow for Clang on top of GCC.