### PR TITLE
Increase duration of mob self-forming from 5 to 10 minutes

### DIFF
--- a/docs/facilitation/2h.md
+++ b/docs/facilitation/2h.md
@@ -5,22 +5,22 @@ Here is a typical time table to make the workshop stick in 2 hours. With this le
 * to let every mob or pair choose their favorite constraint in the second iteration
 * to run an all-in retro at the end to foster interesting discussions
 
-### 1 - Introduction (25 minutes)
+### 1 - Introduction (30 minutes)
 
 | Phase | Style | Length | Start | End |
 |-------|-------|--------|-------|-----|
 | Present the learning goal | All-in | 2 | 0 | 2 |
 | Present the code and the exercise | All-in | 10 | 2 | 12 |
 | Overview of Mikado and Test Data Builders | All-in | 5 | 12 | 17 |
-| Groups self-organization, by language and constraint | All-in | 5 | 17 | 22 |
-| Energizer | Mobs | 3 | 22 | 25 |
+| Mobs self-forming, by language and constraint | All-in | 10 | 17 | 27 |
+| Team building | Mobs | 3 | 27 | 30 |
 	
 ### 2 - Easy Fix, Difficult Test (30 minutes)
 
 | Phase | Style | Length | Start | End |
 |-------|-------|--------|-------|-----|
-| Write the tests | Mobs | 25 | 30 | 50 |
-| Mini retro | Mobs | 5 | 50 | 55 |
+| Write the tests | Mobs | 25 | 30 | 55 |
+| Mini retro | Mobs | 5 | 55 | 60 |
 
 ----
 
@@ -32,14 +32,14 @@ Here is a typical time table to make the workshop stick in 2 hours. With this le
 
 | Phase | Style | Length | Start | End |
 |-------|-------|--------|-------|-----|
-| Learn about constraint | Mobs | 15 | 60 | 75 |
-| Try again to add the tests with this constraint | Mobs | 25 | 75 | 100 |
-| Mini retro | Mobs | 5 | 100 | 105 |
+| Learn about constraint | Mobs | 15 | 65 | 80 |
+| Try again to add the tests with this constraint | Mobs | 25 | 80 | 105 |
+| Mini retro | Mobs | 5 | 105 | 110 |
 	
 ### 4 - All-in Retrospective (10 minutes)
 
 | Phase | Style | Length | Start | End |
 |-------|-------|--------|-------|-----|
-| Every mob picks 1 key takeaway | Mobs | 2 | 105 | 107 |
-| Exchanges and discussion | All-in | 8 | 107 | 115 |
-| Ask for feedback about workshop | All-in | 0 | 115 | 115 |
+| Every mob picks 1 key takeaway | Mobs | 2 | 110 | 112 |
+| Exchanges and discussion | All-in | 8 | 112 | 120 |
+| Ask for feedback about workshop | All-in | 0 | 120 | ... |


### PR DESCRIPTION
It took 10 minutes at Murex, we cannot expect less
- update all timings
- eat up the 5 minutes slack we had backed in...
- rename group into mobs
- use team-building instead of energizer