### PR TITLE
Unix fixes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,6 +24,7 @@ jobs:
         cxx: g++
         build-type: Release
         run-test: true
+        ctest-options: "--output-on-failure"
         install-build: false
   build-clang:
     runs-on: ubuntu-latest
@@ -39,4 +40,5 @@ jobs:
         cxx: clang++
         build-type: Release
         run-test: true
+        ctest-options: "--output-on-failure"
         install-build: false

--- a/cpp/cpp_setup.sh
+++ b/cpp/cpp_setup.sh
@@ -78,4 +78,4 @@ cmake_bin_path="${cmake_build_dir}/${cmake_home}/${cmake_bin_dir}"
 
 eval ${cmake_bin_path}/${cmake} "${cmake_generator_options}" -S .. -B .
 ${cmake_bin_path}/${cmake} --build . --config Debug
-${cmake_bin_path}/${ctest} -C Debug
+${cmake_bin_path}/${ctest} --output-on-failure -C Debug

--- a/cpp/cpp_setup_win.bat
+++ b/cpp/cpp_setup_win.bat
@@ -39,7 +39,7 @@ set CMAKE_BIN_PATH=%CMAKE_BUILD_DIR%\%CMAKE_HOME%\%CMAKE_BIN_DIR%
 
 %CMAKE_BIN_PATH%\%CMAKE% %CMAKE_GENERATOR_OPTIONS% -S .. -B .
 %CMAKE_BIN_PATH%\%CMAKE% --build . --config Debug
-%CMAKE_BIN_PATH%\%CTEST% -C Debug
+%CMAKE_BIN_PATH%\%CTEST% --output-on-failure -C Debug
 
 popd
 

--- a/cpp/src/lib/TaxRule.cpp
+++ b/cpp/src/lib/TaxRule.cpp
@@ -41,14 +41,13 @@ double finance::getApplicableRate(const domain::country::Country& invoiceCountry
 			return 1.05;
 		}
 	}
-	//FIXME does this typeid(thing) work?
 	if (invoiceCountry.getName() == "USA") {
-		if (typeid(book).name() == std::string("class domain::book::Novel")) {
+		if (dynamic_cast<const domain::book::Novel*>(&book)) {
 			return getTaxRate(invoiceCountry.getName()) * 0.98;
 		}
 	}
 	if (invoiceCountry.getName() == "UK") {
-		if (typeid(book).name() == std::string("class domain::book::Novel")) {
+		if (dynamic_cast<const domain::book::Novel*>(&book)) {
 			return getTaxRate(invoiceCountry.getName()) * 0.93;
 		}
 	}


### PR DESCRIPTION
- Fix difference in return value observed in some cases between Windows and Unix-flavored OS's
- Add ctest option allowing to see output when tests are failing